### PR TITLE
directbase: report structured diff on resource creation

### DIFF
--- a/pkg/controller/direct/directbase/directbase_controller.go
+++ b/pkg/controller/direct/directbase/directbase_controller.go
@@ -429,6 +429,11 @@ func (r *reconcileContext) doReconcile(ctx context.Context, u *unstructured.Unst
 
 	if !existsAlready {
 		createOp := NewCreateOperation(r.Reconciler.LifecycleHandler, r.Reconciler.Client, u)
+		diff := structuredreporting.Diff{
+			Object:      u,
+			IsNewObject: true,
+		}
+		structuredreporting.ReportDiff(ctx, &diff)
 		if err := adapter.Create(ctx, createOp); err != nil {
 			if unwrappedErr, ok := lifecyclehandler.CausedByUnresolvableDeps(err); ok {
 				logger.Info(unwrappedErr.Error(), "resource", k8s.GetNamespacedName(u))


### PR DESCRIPTION
This PR ensures that we report a structured diff even when a resource is newly created, improving observability.